### PR TITLE
支持amd64代码下断点

### DIFF
--- a/framework/system/foundation/Bee_Runtime.mm
+++ b/framework/system/foundation/Bee_Runtime.mm
@@ -725,7 +725,7 @@ DEF_SINGLETON( BeeRuntime )
 #if __BEE_DEVELOPMENT__
 #if defined(__ppc__)
 	asm("trap");
-#elif defined(__i386__)
+#elif defined(__i386__) ||  defined(__amd64__)
 	asm("int3");
 #endif	// #elif defined(__i386__)
 #endif	// #if __BEE_DEVELOPMENT__


### PR DESCRIPTION
支持amd64代码下断点，iphone6模拟器等64位配置
