### PR TITLE
Hide the item view before removing.

### DIFF
--- a/framework/mvc/view/dom-element/Bee_UIScrollView.m
+++ b/framework/mvc/view/dom-element/Bee_UIScrollView.m
@@ -1575,12 +1575,13 @@ DEF_SIGNAL( FOOTER_REFRESH )
 		}
 	}
     
+    item.view.hidden = YES;
+    
 	if ( shouldRemove )
 	{
 		[item.view removeFromSuperview];
 	}
-    
-	item.view.hidden = YES;
+
 	item.view = nil;
 	
     PERF_LEAVE


### PR DESCRIPTION
In my iPad mini2, after [item.view removeFromSuperview], when process
item.view.hidden, it will crash, seems the item.view is already released. 
It works fine in simulator.

Hide it first is safe.