### PR TITLE
修复CSS中设置color属性时用十六进制时alpha参数无效的bug

### DIFF
--- a/framework/mvc/view/common/extension/UIColor+BeeExtension.m
+++ b/framework/mvc/view/common/extension/UIColor+BeeExtension.m
@@ -135,12 +135,12 @@
 		if ( color.length == 8 )
 		{
 			NSUInteger hexRGB = strtol(color.UTF8String , nil, 16);
-			return [UIColor fromHexValue:hexRGB];
+			return [UIColor fromHexValue:hexRGB alpha:alpha];
 		}
 		else if ( color.length == 6 )
 		{
 			NSUInteger hexRGB = strtol(color.UTF8String , nil, 16);
-			return [UIColor fromHexValue:hexRGB alpha:1.0f];
+			return [UIColor fromHexValue:hexRGB alpha:alpha];
 		}
 	}
     else


### PR DESCRIPTION
修复CSS中设置color属性时用十六进制时alpha参数无效的bug